### PR TITLE
corrections to make the belongs_to optional in rails 5.1

### DIFF
--- a/lib/stampable.rb
+++ b/lib/stampable.rb
@@ -83,14 +83,14 @@ module Ddb #:nodoc:
 
           class_eval do
             klass = "::#{stamper_class_name.to_s.singularize.camelize}"
-            belongs_to :creator, :class_name => klass, :foreign_key => creator_attribute
-            belongs_to :updater, :class_name => klass, :foreign_key => updater_attribute
+            belongs_to :creator, :class_name => klass, :foreign_key => creator_attribute, optional: true
+            belongs_to :updater, :class_name => klass, :foreign_key => updater_attribute, optional: true
 
             before_validation :set_updater_attribute
             before_validation :set_creator_attribute, :on => :create
 
             if defaults[:deleter]
-              belongs_to :deleter, :class_name => klass, :foreign_key => deleter_attribute
+              belongs_to :deleter, :class_name => klass, :foreign_key => deleter_attribute, optional: true
               before_destroy  :set_deleter_attribute
             end
           end

--- a/lib/stampable.rb
+++ b/lib/stampable.rb
@@ -48,7 +48,7 @@ module Ddb #:nodoc:
           class_attribute  :deleter_attribute
 
           # Define if the belongs_to association should be optional or not
-          # Defaults to true to mantein the old behavior
+          # Defaults to true to mantain the old behavior
           class_attribute  :userstamp_optional
 
         end

--- a/originator.gemspec
+++ b/originator.gemspec
@@ -70,8 +70,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.11"
 
-  s.add_runtime_dependency 'actionpack', '>= 4.0'
-  s.add_runtime_dependency 'activerecord', '>= 4.0'
+  s.add_runtime_dependency 'actionpack', '>= 4.0', '< 5.1' 
+  s.add_runtime_dependency 'activerecord', '>= 4.0', '< 5.1'
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/originator.gemspec
+++ b/originator.gemspec
@@ -70,8 +70,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.11"
 
-  s.add_runtime_dependency 'actionpack', '>= 4.0', '< 5.1'
-  s.add_runtime_dependency 'activerecord', '>= 4.0', '< 5.1'
+  s.add_runtime_dependency 'actionpack', '>= 4.0'
+  s.add_runtime_dependency 'activerecord', '>= 4.0'
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
in the new rails 5.1 version the belongs_to make the association required, to make originator work with applications (like alchemy-cms) that don't require the association of the creator and updater, the change add only the optional: true to the association

it's configurable like the other params, and setup tu be optional as default.