### PR TITLE
Defer loading Rails until actually needed

### DIFF
--- a/lib/migration_helper.rb
+++ b/lib/migration_helper.rb
@@ -16,4 +16,6 @@ module Ddb
   end
 end
 
-ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, Ddb::Userstamp::MigrationHelper)
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, Ddb::Userstamp::MigrationHelper)
+end

--- a/lib/stampable.rb
+++ b/lib/stampable.rb
@@ -157,4 +157,4 @@ module Ddb #:nodoc:
   end
 end
 
-ActiveRecord::Base.send(:include, Ddb::Userstamp::Stampable) if defined?(ActiveRecord)
+ActiveSupport.on_load(:active_record) { include Ddb::Userstamp::Stampable }

--- a/lib/stamper.rb
+++ b/lib/stamper.rb
@@ -40,4 +40,4 @@ module Ddb #:nodoc:
   end
 end
 
-ActiveRecord::Base.send(:include, Ddb::Userstamp::Stamper) if defined?(ActiveRecord)
+ActiveSupport.on_load(:active_record) { include Ddb::Userstamp::Stamper }

--- a/lib/userstamp.rb
+++ b/lib/userstamp.rb
@@ -49,4 +49,4 @@ module Ddb
   end
 end
 
-ActionController::Base.send(:include, Ddb::Controller) if defined?(ActionController)
+ActiveSupport.on_load(:action_controller_base) { include Ddb::Controller }

--- a/originator.gemspec
+++ b/originator.gemspec
@@ -72,6 +72,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'actionpack', '>= 4.0'
   s.add_runtime_dependency 'activerecord', '>= 4.0'
+  s.add_runtime_dependency 'activesupport', '>= 4.0'
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
This uses Rails' `#on_load` hooks to avoid loading ActiveRecord, ActionController, etc. on boot until they are actually needed.